### PR TITLE
Update WeiboModule.java

### DIFF
--- a/android/src/main/java/cn/reactnative/modules/weibo/WeiboModule.java
+++ b/android/src/main/java/cn/reactnative/modules/weibo/WeiboModule.java
@@ -79,6 +79,8 @@ public class WeiboModule extends ReactContextBaseJavaModule implements ActivityE
             throw new Error("meta-data WB_APPID not found in AndroidManifest.xml");
         }
         this.appId = appInfo.metaData.get("WB_APPID").toString();
+        this.appId = this.appId.substring(2);
+
     }
 
     private static final String RCTWBEventName = "Weibo_Resp";


### PR DESCRIPTION
修复数字变成科学计数法的字符串的bug，在安卓下微博的APPID需要设置成带wb前缀。