### PR TITLE
修复安卓RN42+ es-promisify报错的问题【无依赖】

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ import {NativeModules, NativeAppEventEmitter} from 'react-native';
 
 function promisify(fn, handler) {
   return function (...args) {
-    return new Promise(function () {
-      fn(...args, handler.bind(this))
+    return new Promise(function (resolve, reject) {
+      fn(...args, handler.bind({ resolve, reject }))
     })
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,15 @@
  */
 
 import {NativeModules, NativeAppEventEmitter} from 'react-native';
-import promisify from 'es6-promisify';
+
+function promisify(fn, handler) {
+  return function (...args) {
+    return new Promise(function () {
+      fn(...args, handler.bind(this))
+    })
+  }
+}
+
 
 const {WeiboAPI} = NativeModules;
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,5 @@
     "url": "https://github.com/reactnativecn/react-native-weibo/issues"
   },
   "homepage": "https://github.com/reactnativecn/react-native-weibo#readme",
-  "dependencies": {
-    "es6-promisify": "^3.0.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
用如下代码替换了`es-promisify`
``` javascript
function promisify(fn, handler) {
  return function (...args) {
    return new Promise(function (resolve, reject) {
      fn(...args, handler.bind({ resolve, reject }))
    })
  }
}
```